### PR TITLE
Add filterNode and exportLocalVariables methods

### DIFF
--- a/example/acl.js
+++ b/example/acl.js
@@ -1,0 +1,117 @@
+/*jshint esversion:6, node:true*/
+'use strict';
+const Menu = require('..');
+const AccessControl = require('accesscontrol');
+
+let grantList = [
+    { role: 'admin', resource: 'passport', action: 'read:any', attributes: '*' },
+    { role: 'admin', resource: 'hotdesk', action: 'read:any', attributes: '*' },
+    { role: 'admin', resource: 'user', action: 'read:any', attributes: '*' },
+    { role: 'user',  resource: 'hotdesk', action: 'read:any', attributes: '*' },
+    { role: 'user',  resource: 'user', action: 'read:any', attributes: '*' },
+];
+const ac = new AccessControl(grantList);
+
+const topMenu = new Menu('Main', {
+    segment:'/',
+    data: {
+        acl: 'user'
+    },
+    filterNode(node) {
+        console.log('node path', node.uri);
+        let role = this.request.user.role;
+        let resource = node.data.resource;
+        if(!resource) return node;
+
+        console.log('can role "%s" read "%s"?', role, resource, ac.can(role).readAny(resource).granted)
+        if(ac.can(role).readAny(resource).granted) {
+            return node;
+        }
+    }
+});
+
+const adminMenu = new Menu('Admin', {
+    data: {}
+});
+adminMenu.request = {
+    route: {
+        path: '/admin/api/users'
+    }
+};
+
+const consoleMenu = Menu.get('admin').addNode('Debug', {
+
+});
+
+consoleMenu.addNode('WebSocket', {
+
+});
+consoleMenu.addNode('Payloads', {
+
+});
+consoleMenu.addNode('Requests', {
+
+});
+
+const crudMenu = Menu.get('admin').addNode('Crud');
+crudMenu.segment = 'api';
+crudMenu.addNode('Users', {
+    data: { resource: 'user' }
+});
+crudMenu.addNode('Passports', {
+    data: { resource: 'passport' }
+});
+crudMenu.addNode('HotDesks', {
+    data: { resource: 'hotdesk' }
+});
+
+topMenu.addNode(adminMenu);
+topMenu.addNode(crudMenu);
+
+
+const user = { id:1, role:'user' };
+const admin = { id:1, role:'admin' };
+
+console.log('------------ USER MENU --------------');
+Menu.get('main').middleware({path:'/', user:user}, {locals:{}}, _=> {
+    console.log('--- done');
+    let menu = Menu.get('admin').toJSON();
+console.log('<div id="' + menu.id + '" class="ui small menu">');
+    menu.nodes.map(child => {
+        console.log('  <div class="right menu">');
+            console.log('    <div class="ui dropdown item">');
+                console.log('      <i class="dropdown icon"></i>');
+                console.log('      <div class="menu">');
+                child.nodes.map(leaf => {
+                    console.log('        <a class="item">'+leaf.name+'</a>');
+                });
+                console.log('      </div>');
+            console.log('    </div>');
+        console.log('  </div>');
+    });
+    console.log('');
+console.log('</div>');    
+});
+
+
+console.log('------------ ADMIN MENU --------------');
+
+Menu.get('main').middleware({path:'/', user:admin}, {locals:{}}, _=> {
+    console.log('--- done');
+    let menu = Menu.get('admin').toJSON();
+console.log('<div id="' + menu.id + '" class="ui small menu">');
+    menu.nodes.map(child => {
+        console.log('  <div class="right menu">');
+            console.log('    <div class="ui dropdown item">');
+                console.log('      <i class="dropdown icon"></i>');
+                console.log('      <div class="menu">');
+                child.nodes.map(leaf => {
+                    console.log('        <a class="item">'+leaf.name+'</a>');
+                });
+                console.log('      </div>');
+            console.log('    </div>');
+        console.log('  </div>');
+    });
+    console.log('');
+console.log('</div>');    
+});

--- a/lib/menu.js
+++ b/lib/menu.js
@@ -86,13 +86,32 @@ class Menu {
         let name = this.root.localName;
 
         if (locals && !locals[name]) {
-            locals[name] = this.root.toJSON();
+            locals[name] = this.exportLocalVariables(req);
         } else {
             this.logger.warn('We are not exporting %s.', name);
             this.logger.warn('There exists a local with that name');
         }
 
         next();
+    }
+
+    /**
+     * Stub implementation of function to 
+     * filter out nodes.
+     *  
+     * @param {http.IncommingRequest}
+     * @returns {Object} Object with nodes
+     */
+    exportLocalVariables(req) {
+        return this.root.toJSON();
+    }
+
+    filterNode(node) {
+        if(this.parent && typeof this.parent.filterNode === 'function') {
+            return this.parent.filterNode(node);
+        }
+
+        return node;
     }
 
     find(nodeId) {
@@ -173,7 +192,7 @@ class Menu {
         if (this.isLeaf) {
             delete item.nodes;
         } else {
-            item.nodes = this.nodes.map(node => node.toJSON());
+            item.nodes = this.nodes.map(node => node.toJSON()).filter(Boolean);
         }
 
         item.isActive = this.isActive;
@@ -186,6 +205,8 @@ class Menu {
         } else {
             delete item.breadcrumbs;
         }
+
+        item = this.filterNode(item);
 
         return item;
     }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "slug": "^0.9.1"
   },
   "devDependencies": {
+    "accesscontrol": "^2.2.1",
     "bogota": "^2.0.4",
     "nyc": "^10.3.2",
     "sinon": "^2.2.0",


### PR DESCRIPTION
This closes #9 by providing means to filter out nodes.

* Added `exportLocalVariables`
* Added `filterNode`

These two methods enable filtering out nodes from the tree before rendering the content.

Added an example showing how to combine these with the [accesscontrol](https://onury.io/accesscontrol/) library.